### PR TITLE
Release pipeline fixes: macOS universal2 + twine check env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,8 +78,9 @@ jobs:
           - { os: ubuntu-latest, platform: linux, target: x86_64, manylinux: musllinux_1_2 }
           - { os: ubuntu-latest, platform: linux, target: aarch64, manylinux: musllinux_1_2 }
           - { os: windows-latest, platform: windows, target: x64 }
-          - { os: macos-13, platform: macos, target: x86_64 }
-          - { os: macos-14, platform: macos, target: aarch64 }
+          # One universal2 wheel (Intel + Apple Silicon) cross-built on the
+          # fast arm64 runner — avoids the scarce/slow macos-13 Intel runners.
+          - { os: macos-14, platform: macos, target: universal2-apple-darwin }
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,11 +126,17 @@ jobs:
         with:
           name: sdist
           path: dist
+      # A clean interpreter so a fresh `packaging` is used: the runner's
+      # system packaging is too old to recognise the Metadata 2.4
+      # `License-File` field and makes `twine check` spuriously fail.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
       - name: List and check
         run: |
           ls -la dist/
           echo "wheels: $(ls dist/*.whl | wc -l), sdists: $(ls dist/*.tar.gz | wc -l)"
-          pip install twine
+          python -m pip install --upgrade twine packaging
           twine check dist/*
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Follow-up fixes to the release workflow, validated by a full TestPyPI dry run.

## Changes
- **macOS universal2 wheel**: replace the separate `macos-13` (Intel) and `macos-14` (arm64) wheel jobs with a single `universal2` cross-build on `macos-14`. GitHub's Intel macOS runners queue for a long time as capacity moves to Apple Silicon; this removes that dependency while still shipping a wheel that runs on both Intel and Apple Silicon Macs.
- **twine check environment**: the `collect` job ran twine on the runner's system Python, whose stale `packaging` doesn't recognise the Metadata 2.4 `License-File` field, causing a spurious `twine check` failure. Now uses `actions/setup-python` with an upgraded `twine`/`packaging`.

## Validation
Dispatched `release.yml` against this branch targeting **TestPyPI** — full pipeline green: version check, test gate, all 6 wheels (macOS universal2, manylinux + musllinux x86_64/aarch64, Windows) + sdist, `twine check`, and the trusted-publishing upload. Confirmed `rstar-python 0.1.0` is live on TestPyPI with all artifacts.